### PR TITLE
Only calc modded secondary factors for humanlikes.

### DIFF
--- a/Source/Gradual Romance/GRSecondaryLovinChanceFactorPatch.cs
+++ b/Source/Gradual Romance/GRSecondaryLovinChanceFactorPatch.cs
@@ -11,6 +11,7 @@ public static class GRSecondaryLovinChanceFactorPatch
     [HarmonyPriority(Priority.VeryHigh)]
     public static void GRSecondaryLovinChanceFactor(ref float __result, ref Pawn ___pawn, Pawn otherPawn)
     {
-        __result = AttractionUtility.CalculateAttraction(___pawn, otherPawn, true, false);
+        if ((___pawn?.RaceProps?.Humanlike ?? false) && (otherPawn?.RaceProps?.Humanlike ?? false))
+            __result = AttractionUtility.CalculateAttraction(___pawn, otherPawn, true, false);
     }
 }

--- a/Source/Gradual Romance/GRSecondaryRomanceChanceFactorPatch.cs
+++ b/Source/Gradual Romance/GRSecondaryRomanceChanceFactorPatch.cs
@@ -11,6 +11,7 @@ public static class GRSecondaryRomanceChanceFactorPatch
     [HarmonyPriority(Priority.VeryHigh)]
     public static void GRSecondaryRomanceChanceFactor(ref float __result, ref Pawn ___pawn, Pawn otherPawn)
     {
-        __result = AttractionUtility.CalculateAttraction(___pawn, otherPawn, false, true);
+        if ((___pawn?.RaceProps?.Humanlike ?? false) && (otherPawn?.RaceProps?.Humanlike ?? false))
+            __result = AttractionUtility.CalculateAttraction(___pawn, otherPawn, false, true);
     }
 }


### PR DESCRIPTION
This mod has additional computations for secondary lovin' and romance chance factors. Previously, these values were computed for any pawn in regards to any other pawn. This change makes it only perform these computations between two humanlike pawns. Non-humanlike pawns, such as animals, are missing some of the components used in these computations, leading to errors.

This is a bit of a "heavy handed" fix, as it just prevents this mod from performing those calculations when one or more of the pawns are non-humanlike. The individual AttractionCalculator classes that are throwing errors can also be updated to be more robust. However, this PR is a straightforward way to prevent errors being thrown when mousing over the relevant items in a pawn's social, and we aren't losing anything by not having these full calculations between a pawn and and animal or two animals.

Fixes #3.