### PR TITLE
Check for null needs for hygiene attraction.

### DIFF
--- a/Source/Gradual Romance/AttractionCalculators/AttractionCalculator_Hygiene.cs
+++ b/Source/Gradual Romance/AttractionCalculators/AttractionCalculator_Hygiene.cs
@@ -11,7 +11,8 @@ public class AttractionCalculator_Hygiene : AttractionCalculator
 
     public override bool Check(Pawn observer, Pawn assessed)
     {
-        return ModHooks.UsingDubsHygiene() && assessed.needs.AllNeeds.Any(x => x.def.defName == "Hygiene");
+        return ModHooks.UsingDubsHygiene() &&
+            (assessed?.needs?.AllNeeds?.Any(x => x.def.defName == "Hygiene") ?? false);
     }
 
     public override float Calculate(Pawn observer, Pawn assessed)


### PR DESCRIPTION
Specifically, dead pawns don't have needs, so mousing over a dead lover/etc. in a pawn's social tab was throwing NREs while attempting to calculate secondary lovin'/romance chance factors.

Note that it is a vanilla feature to compute these chance factors with dead pawns in the first place.

This appears to be the only AttractionCalculator that assumes the pawns in question have needs.

For reference, an example NRE from this bug:

```
System.NullReferenceException: Object reference not set to an instance of an object
  at Gradual_Romance.AttractionCalculator_Hygiene.Check (Verse.Pawn observer, Verse.Pawn assessed) [0x00008] in <095b32abca014d6d91e49a0cabe560df>:0 
  at Gradual_Romance.AttractionUtility.CalculateAttractionCategory (Gradual_Romance.AttractionFactorCategoryDef category, Verse.Pawn observer, Verse.Pawn assessed, System.Collections.Generic.List`1[Gradual_Romance.AttractionFactorDef]& veryLowFactors, System.Collections.Generic.List`1[Gradual_Romance.AttractionFactorDef]& lowFactors, System.Collections.Generic.List`1[Gradual_Romance.AttractionFactorDef]& highFactors, System.Collections.Generic.List`1[Gradual_Romance.AttractionFactorDef]& veryHighFactors, Gradual_Romance.AttractionFactorDef& reasonForInstantFailure) [0x0006b] in <095b32abca014d6d91e49a0cabe560df>:0 
  at (wrapper dynamic-method) Gradual_Romance.AttractionUtility.Gradual_Romance.AttractionUtility.CalculateAttraction_Patch0(Verse.Pawn,Verse.Pawn,bool,bool,System.Collections.Generic.List`1<Gradual_Romance.AttractionFactorDef>&,System.Collections.Generic.List`1<Gradual_Romance.AttractionFactorDef>&,System.Collections.Generic.List`1<Gradual_Romance.AttractionFactorDef>&,System.Collections.Generic.List`1<Gradual_Romance.AttractionFactorDef>&,Gradual_Romance.AttractionFactorDef&)
  at Gradual_Romance.AttractionUtility.CalculateAttraction (Verse.Pawn observer, Verse.Pawn assessed, System.Boolean attractionOnly, System.Boolean formalRelationship) [0x00001] in <095b32abca014d6d91e49a0cabe560df>:0 
  at Gradual_Romance.Harmony.GRSecondaryLovinChanceFactorPatch.GRSecondaryLovinChanceFactor (System.Single& __result, Verse.Pawn& ___pawn, Verse.Pawn otherPawn) [0x00001] in <095b32abca014d6d91e49a0cabe560df>:0 
  at (wrapper dynamic-method) RimWorld.Pawn_RelationsTracker.RimWorld.Pawn_RelationsTracker.SecondaryLovinChanceFactor_Patch2(RimWorld.Pawn_RelationsTracker,Verse.Pawn)
  at (wrapper dynamic-method) RimWorld.Pawn_RelationsTracker.RimWorld.Pawn_RelationsTracker.SecondaryRomanceChanceFactor_Patch1(RimWorld.Pawn_RelationsTracker,Verse.Pawn)
  at RimWorld.SocialCardUtility.GetPawnRowTooltip (RimWorld.SocialCardUtility+CachedSocialTabEntry entry, Verse.Pawn selPawnForSocialInfo) [0x0014c] in <95de19971c5d40878d8742747904cdcd>:0 
  at RimWorld.SocialCardUtility+<>c__DisplayClass50_0.<DrawPawnRow>b__0 () [0x00000] in <95de19971c5d40878d8742747904cdcd>:0 
  at (wrapper dynamic-method) Verse.ActiveTip.Verse.ActiveTip.get_FinalText_Patch0(Verse.ActiveTip)
UnityEngine.StackTraceUtility:ExtractStackTrace ()
(wrapper dynamic-method) Verse.Log:Verse.Log.Error_Patch5 (string)
(wrapper dynamic-method) Verse.ActiveTip:Verse.ActiveTip.get_FinalText_Patch0 (Verse.ActiveTip)
(wrapper dynamic-method) Verse.ActiveTip:Verse.ActiveTip.get_TipRect_Patch1 (Verse.ActiveTip)
Verse.TooltipHandler:CalculateInitialTipPosition (System.Collections.Generic.List`1<Verse.ActiveTip>)
Verse.TooltipHandler:DrawActiveTips ()
(wrapper dynamic-method) Verse.TooltipHandler:Verse.TooltipHandler.DoTooltipGUI_Patch1 ()
(wrapper dynamic-method) Verse.UIRoot:Verse.UIRoot.UIRootOnGUI_Patch8 (Verse.UIRoot)
(wrapper dynamic-method) RimWorld.UIRoot_Play:RimWorld.UIRoot_Play.UIRootOnGUI_Patch4 (RimWorld.UIRoot_Play)
(wrapper dynamic-method) Verse.Root:Verse.Root.OnGUI_Patch2 (Verse.Root)
```